### PR TITLE
fix : Menu 엔티티 RegistrationDate 필드 Timestamp 타입 변환(#25)

### DIFF
--- a/src/main/java/hello/cafemate/domain/Menu.java
+++ b/src/main/java/hello/cafemate/domain/Menu.java
@@ -3,7 +3,7 @@ package hello.cafemate.domain;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.sql.Timestamp;
 
 @Getter
 @EqualsAndHashCode
@@ -13,12 +13,12 @@ public class Menu {
     private Category category;
     private int price;
     private boolean onSale;
-    private LocalDateTime registrationDate;
+    private Timestamp registrationDate;
 
     public Menu() {
     }
 
-    public Menu(Long id, String name, Category category, int price, boolean onSale, LocalDateTime registrationDate) {
+    public Menu(Long id, String name, Category category, int price, boolean onSale, Timestamp registrationDate) {
         this.id = id;
         this.name = name;
         this.category = category;
@@ -27,7 +27,7 @@ public class Menu {
         this.registrationDate = registrationDate;
     }
 
-    public Menu(String name, Category category, int price, boolean onSale, LocalDateTime registrationDate) {
+    public Menu(String name, Category category, int price, boolean onSale, Timestamp registrationDate) {
         this.name = name;
         this.category = category;
         this.price = price;

--- a/src/main/java/hello/cafemate/dto/simple_dto/MemberDto.java
+++ b/src/main/java/hello/cafemate/dto/simple_dto/MemberDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public class MemberDto {
     private String memberId;
+
     private String password;
     private String name;
     private String phoneNumber;

--- a/src/main/java/hello/cafemate/dto/simple_dto/MenuDto.java
+++ b/src/main/java/hello/cafemate/dto/simple_dto/MenuDto.java
@@ -3,6 +3,7 @@ package hello.cafemate.dto.simple_dto;
 import hello.cafemate.domain.Category;
 import lombok.Getter;
 
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 @Getter
@@ -11,10 +12,10 @@ public class MenuDto {
     private Category category;
     private int price;
     private boolean onSale;
-    private LocalDateTime registrationDate;
+    private Timestamp registrationDate;
 
     public MenuDto(String name, Category category,
-                   int price, boolean onSale, LocalDateTime registrationDate) {
+                   int price, boolean onSale, Timestamp registrationDate) {
         this.name = name;
         this.category = category;
         this.price = price;

--- a/src/main/java/hello/cafemate/dto/update_dto/MenuUpdateDto.java
+++ b/src/main/java/hello/cafemate/dto/update_dto/MenuUpdateDto.java
@@ -4,7 +4,7 @@ import hello.cafemate.domain.Category;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
+import java.sql.Timestamp;
 
 @Getter
 @Setter
@@ -13,7 +13,7 @@ public class MenuUpdateDto {
     private Category category;
     private Integer price;
     private Boolean onSale;
-    private LocalDateTime registrationDate;
+    private Timestamp registrationDate;
 
     public MenuUpdateDto(){}
 }

--- a/src/main/java/hello/cafemate/repository/MenuRepository.java
+++ b/src/main/java/hello/cafemate/repository/MenuRepository.java
@@ -136,7 +136,7 @@ public class MenuRepository extends AbstractRepository<Menu, MenuUpdateDto> {
                 Category.valueOf(rs.getString("category")),
                 rs.getInt("price"),
                 rs.getInt("on_sale")==0?true:false,
-                rs.getTimestamp("registration_date").toLocalDateTime()
+                rs.getTimestamp("registration_date")
         );
     }
 


### PR DESCRIPTION
DB에 해당 값을 저장했다가 조회할 시 기존의 LocalDatetime 의 경우
나노초 단위 값이 올림된 상태로 찾아져 코드 사이드에서 저장한 형태와
불일치가 발생하는 오류가 존재했다. 비즈니스 로직상 나노 초단위 데이터는
중요도가 크지 않은 것으로 판단해 필드 타입을 변경하고 관련 코드들을
일괄적으로 수정하였다.

해결 : close #25