### PR TITLE
refactor : amount 필드명 오타, quantity 로 정정

### DIFF
--- a/src/main/java/hello/cafemate/dao/OrderResponseDao.java
+++ b/src/main/java/hello/cafemate/dao/OrderResponseDao.java
@@ -7,12 +7,12 @@ import java.sql.Timestamp;
 @Getter
 public class OrderResponseDao {
     private Long orderId;
-    private Integer amount;
+    private Integer quantity;
     private Timestamp orderDate;
 
-    public OrderResponseDao(Long orderId, Integer amount, Timestamp orderDate) {
+    public OrderResponseDao(Long orderId, Integer quantity, Timestamp orderDate) {
         this.orderId = orderId;
-        this.amount = amount;
+        this.quantity = quantity;
         this.orderDate = orderDate;
     }
 }

--- a/src/main/java/hello/cafemate/repository/OrderRepository.java
+++ b/src/main/java/hello/cafemate/repository/OrderRepository.java
@@ -97,7 +97,7 @@ public class OrderRepository extends AbstractRepository<Order, OrderUpdateDto> {
     }
 
     public OrderResponseDao findOrderResponseDaoById(Long id) {
-        String sql = "select id, amount, orders_date" +
+        String sql = "select id, quantity, orders_date" +
                 " from orders where id=:id";
 
         MapSqlParameterSource param =
@@ -106,7 +106,7 @@ public class OrderRepository extends AbstractRepository<Order, OrderUpdateDto> {
         return template.queryForObject(sql, param, (rs, rowNum) ->
                 new OrderResponseDao(
                         rs.getLong("id"),
-                        rs.getInt("amount"),
+                        rs.getInt("quantity"),
                         rs.getTimestamp("orders_date")
                 )
         );


### PR DESCRIPTION
OrderRepository 의 findOrderResponseDaoById 메서드의 쿼리와 OrderResponseDao의 필드에 잘못 표기된 필드명 amount, quantity로 정정